### PR TITLE
Use sphinx-codeautolink extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,10 +10,12 @@ extensions = [
     'sphinx.ext.todo',
     'nbsphinx',
     'sphinx_last_updated_by_git',
+    'sphinx_codeautolink',
 ]
 
 intersphinx_mapping = {
     'splines': ('https://splines.readthedocs.io/', None),
+    'sympy': ('https://docs.sympy.org/latest/', None),
 }
 
 todo_include_todos = True

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ nbsphinx
 ipykernel
 sympy
 sphinx-last-updated-by-git
+sphinx-codeautolink


### PR DESCRIPTION
Doesn't seem to work yet on RTD.
There are some warnings in the build logs: https://readthedocs.org/projects/audioscenedescriptionformat/builds/15655118/

Rendered: https://audioscenedescriptionformat--3.org.readthedocs.build/en/3/quaternions.html